### PR TITLE
reside-128: 5 identical agents

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,8 +20,8 @@ Vagrant.configure("2") do |config|
   end
 
   agents.each do |agent|
-    config.vm.define agent[:hostname] do |agent_config|
-      agent_config.vm.hostname = agent[:hostname] + '.localdomain'
+    config.vm.define agent do |agent_config|
+      agent_config.vm.hostname = agent + '.localdomain'
     end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,9 @@ if !File.file?(vault_config_file)
 end
 
 vault_config = Hash[File.read(vault_config_file).split("\n").
-                     map{|s| s.split('=')}]
+                      map{|s| s.split('=')}]
+
+agents = (1..5).map { |x| "agent-" + x.to_s }
 
 Vagrant.configure("2") do |config|
   config.vm.box = "builds/virtualbox-ubuntu1804.box"
@@ -16,5 +18,10 @@ Vagrant.configure("2") do |config|
     shell.path = 'provision/start-agent.sh'
     shell.env = vault_config
   end
-    
+
+  agents.each do |agent|
+    config.vm.define agent[:hostname] do |agent_config|
+      agent_config.vm.hostname = agent[:hostname] + '.localdomain'
+    end
+  end
 end


### PR DESCRIPTION
This PR creates 5 agents from one Vagrantfile - as with everything Ruby it took a while to sort out.  I've run this on logs@logs from this branch and build agents are reporting in: https://buildkite.com/organizations/mrc-ide/agents