### PR TITLE
reside-138: Add another pair of agents

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ end
 vault_config = Hash[File.read(vault_config_file).split("\n").
                       map{|s| s.split('=')}]
 
-agents = (1..5).map { |x| "agent-" + x.to_s }
+agents = (1..7).map { |x| "agent-" + x.to_s }
 
 Vagrant.configure("2") do |config|
   config.vm.box = "builds/virtualbox-ubuntu1804.box"


### PR DESCRIPTION
This PR will add another pair of agents to the pool on logs.dide

With 7 * 17.5 we get to 122 GB which is comfortably below the 141
that the machine has, plus one core left over (it has 8).  Seems
about the most we'd want to use