### PR TITLE
reside-187 install pip on agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ output-virtualbox-iso
 builds
 .vagrant
 vault_config
+.idea

--- a/packer-config.json
+++ b/packer-config.json
@@ -23,6 +23,11 @@
       "type": "shell",
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "script": "scripts/setup-vault.sh"
+    },
+    {
+      "type": "shell",
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "script": "scripts/setup-pip.sh"
     }
   ],
   "builders": [

--- a/scripts/setup-pip.sh
+++ b/scripts/setup-pip.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -ex
+
+if which -a pip3 > /dev/null; then
+    echo "pip3 is already installed"
+    exit 0
+fi
+
+echo "installing pip3"
+
+sudo apt-get update & sudo apt-get install python3-pip


### PR DESCRIPTION
Self explanatory; boxes have python3 by default but not pip. Needed for some builds