### PR TITLE
mrc-1816 add python bin path to PATH on agents

### DIFF
--- a/provision/start-agent.sh
+++ b/provision/start-agent.sh
@@ -41,6 +41,10 @@ $AS_AGENT git config --global user.email "rich.fitzjohn+vimc@gmail.com"
 $AS_AGENT git config --global user.name "vimc-robot"
 $AS_AGENT git config --global push.default simple
 
+sudo mkdir -p /etc/systemd/system/buildkite-agent.service.d
+echo "[Service]" | sudo tee -a /etc/systemd/system/buildkite-agent.service.d/env.conf
+echo "Environment=PATH=/var/lib/buildkite-agent/.local/bin:usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin" | sudo tee -a /etc/systemd/system/buildkite-agent.service.d/env.conf
+
 cat <<EOF > /etc/cron.daily/docker-cleanup
 #!/usr/bin/env bash
 docker system prune -af --volumes

--- a/provision/start-agent.sh
+++ b/provision/start-agent.sh
@@ -41,9 +41,7 @@ $AS_AGENT git config --global user.email "rich.fitzjohn+vimc@gmail.com"
 $AS_AGENT git config --global user.name "vimc-robot"
 $AS_AGENT git config --global push.default simple
 
-sudo mkdir -p /etc/systemd/system/buildkite-agent.service.d
-echo "[Service]" | sudo tee -a /etc/systemd/system/buildkite-agent.service.d/env.conf
-echo "Environment=PATH=/var/lib/buildkite-agent/.local/bin:usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin" | sudo tee -a /etc/systemd/system/buildkite-agent.service.d/env.conf
+echo 'export PATH=/var/lib/buildkite-agent/.local/bin:$PATH' | sudo tee -a /etc/buildkite-agent/hooks/environment
 
 cat <<EOF > /etc/cron.daily/docker-cleanup
 #!/usr/bin/env bash


### PR DESCRIPTION
This PR adds a buildkite hook to set the PATH env var on agents so that it includes python's script install directory.